### PR TITLE
Memory benchmarking, auto report generation github action

### DIFF
--- a/.github/workflows/memory-report.yml
+++ b/.github/workflows/memory-report.yml
@@ -41,5 +41,6 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add reports/memory.csv
-          git diff --cached --quiet || git commit -m "chore: update memory report [skip ci]"
+          git commit -m "chore: update memory report [skip ci]" || exit 0
+          git pull --rebase origin main
           git push

--- a/.github/workflows/memory-report.yml
+++ b/.github/workflows/memory-report.yml
@@ -1,0 +1,45 @@
+name: Memory Report
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  memory-report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install memray
+
+      - name: Run memory comparison
+        run: |
+          export PYTHONPATH=.
+          mkdir -p reports
+          DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          COMMIT="${{ github.sha }}"
+
+          if [ ! -f reports/memory.csv ]; then
+            echo "date,commit,window_size,none_mib,conservative_mib,aggressive_mib" > reports/memory.csv
+          fi
+
+          for ws in 50 100 200 400; do
+            row=$(python tools/compare_memory.py data/test_cases --all-cases --window-size $ws --csv)
+            echo "$DATE,$COMMIT,$row" >> reports/memory.csv
+          done
+
+      - name: Commit report
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add reports/memory.csv
+          git diff --cached --quiet || git commit -m "chore: update memory report [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -119,6 +119,31 @@ python3 tools/race_detector.py data/test_cases/race01_relaxed_ww/ --pruning-mode
 
 ---
 
+## 5. Memory Comparison
+
+`tools/compare_memory.py` measures peak memory for each pruning strategy using [memray](https://github.com/bloomberg/memray).
+
+```shell
+pip install memray
+```
+
+Run on a single test case or all cases at once:
+
+```shell
+# all test cases
+python tools/compare_memory.py data/test_cases --all-cases --window-size 100
+
+# single directory
+python tools/compare_memory.py data/test_cases/race06_three_thread --window-size 100
+```
+
+Use `--csv` to print a raw data row (`window_size,none,conservative,aggressive`) instead of the formatted table. It is used in the GitHub Action to append results to `reports/memory.csv`.
+
+Results are tracked over time in `reports/memory.csv` via the [Memory Report](.github/workflows/memory-report.yml) GitHub Action, which runs on every push to `main` across window sizes 50, 100, 200, and 400.
+
+---
+
 ## Requirements
 *   **Python 3.x**
 *   **Graphviz:** Required for PNG generation.
+*   **memray:** For memory profiling in `compare_memory.py`.

--- a/tools/compare_memory.py
+++ b/tools/compare_memory.py
@@ -25,10 +25,10 @@ def peak_mb(bin_file):
     with memray.FileReader(bin_file) as reader:
         return reader.metadata.peak_memory / (1024 * 1024)
 
-def run_strategy(strategy, dirs, bin_file):
+def run_strategy(factory, args, dirs, bin_file):
     with memray.Tracker(bin_file):
         for d in dirs:
-            detect_from_multiple_executions(d, strategy)
+            detect_from_multiple_executions(d, factory(args))
     return peak_mb(bin_file)
 
 def has_executions(d):
@@ -70,7 +70,7 @@ def main():
     for name, factory in STRATEGIES.items():
         bin_file = os.path.join(tmpdir, f"{name}.bin")
         print(f"  [{name}] running...", end=" ", flush=True)
-        peak = run_strategy(factory(args), dirs, bin_file)
+        peak = run_strategy(factory, args, dirs, bin_file)
         results[name] = (peak, bin_file)
         print(f"{peak:.3f} MiB")
 

--- a/tools/compare_memory.py
+++ b/tools/compare_memory.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Usage:
+#   python tools/compare_memory.py data/test_cases/race06_three_thread
+#   python tools/compare_memory.py data/test_cases --all-cases [--keep-bins]
+
+import os
+import sys
+import argparse
+import tempfile
+import shutil
+import memray
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from algorithm.prune import AggressivePruningStrategy, ConservativePruningStrategy, NoPruningStrategy
+from algorithm.race import detect_from_multiple_executions
+
+STRATEGIES = {
+    "none":         lambda args: NoPruningStrategy(),
+    "conservative": lambda args: ConservativePruningStrategy(prune_interval=args.prune_interval),
+    "aggressive":   lambda args: AggressivePruningStrategy(args.window_size, prune_interval=args.prune_interval),
+}
+
+def peak_mb(bin_file):
+    with memray.FileReader(bin_file) as reader:
+        return reader.metadata.peak_memory / (1024 * 1024)
+
+def run_strategy(strategy, dirs, bin_file):
+    with memray.Tracker(bin_file):
+        for d in dirs:
+            detect_from_multiple_executions(d, strategy)
+    return peak_mb(bin_file)
+
+def has_executions(d):
+    return any(f.startswith("execution_") and f.endswith(".json") for f in os.listdir(d))
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path")
+    parser.add_argument("--all-cases", action="store_true")
+    parser.add_argument("--window-size",    type=int, default=300)
+    parser.add_argument("--prune-interval", type=int, default=16)
+    parser.add_argument("--keep-bins",      action="store_true")
+    parser.add_argument("--csv",            action="store_true", help="Print results as a CSV row (no header)")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.path):
+        print(f"Directory not found: {args.path}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.all_cases:
+        dirs = sorted(
+            os.path.join(args.path, d) for d in os.listdir(args.path)
+            if os.path.isdir(os.path.join(args.path, d)) and has_executions(os.path.join(args.path, d))
+        )
+        if not dirs:
+            print(f"No execution subdirectories found under: {args.path}", file=sys.stderr)
+            sys.exit(1)
+        print(f"Running on {len(dirs)} test cases (window={args.window_size}, interval={args.prune_interval})\n")
+    else:
+        if not has_executions(args.path):
+            print(f"No execution_*.json files found in: {args.path}", file=sys.stderr)
+            sys.exit(1)
+        dirs = [args.path]
+        print(f"Running on: {args.path} (window={args.window_size}, interval={args.prune_interval})\n")
+
+    tmpdir = tempfile.mkdtemp(prefix="memray_compare_")
+    results = {}
+
+    for name, factory in STRATEGIES.items():
+        bin_file = os.path.join(tmpdir, f"{name}.bin")
+        print(f"  [{name}] running...", end=" ", flush=True)
+        peak = run_strategy(factory(args), dirs, bin_file)
+        results[name] = (peak, bin_file)
+        print(f"{peak:.3f} MiB")
+
+    baseline = results["none"][0]
+    if args.csv:
+        peaks = [f"{results[n][0]:.3f}" for n in STRATEGIES]
+        print(",".join([str(args.window_size)] + peaks))
+    else:
+        print(f"\n{'Strategy':<15} {'Peak (MiB)':>12} {'vs none':>10}")
+        print("-" * 40)
+        for name, (peak, _) in results.items():
+            pct = (peak - baseline) / baseline * 100 if baseline > 0 else 0
+            sign = "+" if pct >= 0 else ""
+            print(f"{name:<15} {peak:>12.3f} {sign}{pct:.1f}%")
+
+    if args.keep_bins:
+        print(f"\nBin files: {tmpdir}/")
+        for name in results:
+            print(f"  memray flamegraph {tmpdir}/{name}.bin")
+    else:
+        shutil.rmtree(tmpdir)
+
+if __name__ == "__main__":
+    main()

--- a/tools/compare_memory.py
+++ b/tools/compare_memory.py
@@ -67,31 +67,33 @@ def main():
     tmpdir = tempfile.mkdtemp(prefix="memray_compare_")
     results = {}
 
-    for name, factory in STRATEGIES.items():
-        bin_file = os.path.join(tmpdir, f"{name}.bin")
-        print(f"  [{name}] running...", end=" ", flush=True)
-        peak = run_strategy(factory, args, dirs, bin_file)
-        results[name] = (peak, bin_file)
-        print(f"{peak:.3f} MiB")
+    try:
+        for name, factory in STRATEGIES.items():
+            bin_file = os.path.join(tmpdir, f"{name}.bin")
+            print(f"  [{name}] running...", end=" ", flush=True)
+            peak = run_strategy(factory, args, dirs, bin_file)
+            results[name] = (peak, bin_file)
+            print(f"{peak:.3f} MiB")
 
-    baseline = results["none"][0]
-    if args.csv:
-        peaks = [f"{results[n][0]:.3f}" for n in STRATEGIES]
-        print(",".join([str(args.window_size)] + peaks))
-    else:
-        print(f"\n{'Strategy':<15} {'Peak (MiB)':>12} {'vs none':>10}")
-        print("-" * 40)
-        for name, (peak, _) in results.items():
-            pct = (peak - baseline) / baseline * 100 if baseline > 0 else 0
-            sign = "+" if pct >= 0 else ""
-            print(f"{name:<15} {peak:>12.3f} {sign}{pct:.1f}%")
+        baseline = results["none"][0]
+        if args.csv:
+            peaks = [f"{results[n][0]:.3f}" for n in STRATEGIES]
+            print(",".join([str(args.window_size)] + peaks))
+        else:
+            print(f"\n{'Strategy':<15} {'Peak (MiB)':>12} {'vs none':>10}")
+            print("-" * 40)
+            for name, (peak, _) in results.items():
+                pct = (peak - baseline) / baseline * 100 if baseline > 0 else 0
+                sign = "+" if pct >= 0 else ""
+                print(f"{name:<15} {peak:>12.3f} {sign}{pct:.1f}%")
 
-    if args.keep_bins:
-        print(f"\nBin files: {tmpdir}/")
-        for name in results:
-            print(f"  memray flamegraph {tmpdir}/{name}.bin")
-    else:
-        shutil.rmtree(tmpdir)
+        if args.keep_bins:
+            print(f"\nBin files: {tmpdir}/")
+            for name in results:
+                print(f"  memray flamegraph {tmpdir}/{name}.bin")
+    finally:
+        if not args.keep_bins:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Related to #9 

This pull request introduces a new memory profiling and reporting workflow for the project, allowing for automated tracking and comparison of memory usage across different pruning strategies. The main changes are the addition of a memory comparison script, integration of a GitHub Actions workflow to automate memory reporting, and updates to the documentation to describe these new features.

**Memory profiling and reporting:**

* Added a new script `tools/compare_memory.py` that measures peak memory usage for each pruning strategy (`none`, `conservative`, `aggressive`) using the `memray` library. The script supports both single test case and batch modes, outputs results in table or CSV format, and can retain profiling data for further analysis.
* Introduced a new GitHub Actions workflow `.github/workflows/memory-report.yml` that runs the memory comparison script on every push to `main` for multiple window sizes, appends results to `reports/memory.csv`, and commits updates to the repository.

**Documentation updates:**

* Updated `README.md` to document the usage of `tools/compare_memory.py`, describe the memory profiling workflow, and list `memray` as a requirement. The documentation also explains how results are tracked over time via the new GitHub Action and CSV report.